### PR TITLE
Cancun upgrade: Add `EIP-4844` & `EIP-4788` support

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -85,6 +85,15 @@ class Header extends EthObject {
     rpcResult.gasLimit = web3.utils.toHex(rpcResult.gasLimit)
     rpcResult.gasUsed = web3.utils.toHex(rpcResult.gasUsed)
     rpcResult.timestamp = web3.utils.toHex(rpcResult.timestamp)
+    if (rpcResult.baseFeePerGas !== undefined && rpcResult.baseFeePerGas !== null) {
+      rpcResult.baseFeePerGas = web3.utils.toHex(rpcResult.baseFeePerGas)
+    }
+    if (rpcResult.blobGasUsed !== undefined && rpcResult.blobGasUsed !== null) {
+      rpcResult.blobGasUsed = web3.utils.toHex(rpcResult.blobGasUsed)
+    }
+    if (rpcResult.excessBlobGas !== undefined && rpcResult.excessBlobGas !== null) {
+      rpcResult.excessBlobGas = web3.utils.toHex(rpcResult.excessBlobGas)
+    }
     return this.fromRpc(rpcResult)
   }
 }

--- a/src/header.js
+++ b/src/header.js
@@ -24,8 +24,9 @@ class Header extends EthObject {
       'nonce',
       'baseFeePerGas',
       'withdrawalsRoot',
-      'dataGasUsed',
-      'excessDataGas'
+      'blobGasUsed',
+      'excessBlobGas',
+      'parentBeaconBlockRoot'
     ]
   }
 
@@ -62,11 +63,14 @@ class Header extends EthObject {
       if (rpcResult.withdrawalsRoot !== undefined && rpcResult.withdrawalsRoot !== null) {
         data.push(toBuffer(rpcResult.withdrawalsRoot));
       }
-      if (rpcResult.dataGasUsed !== undefined && rpcResult.dataGasUsed !== null) {
-        data.push(toBuffer(rpcResult.dataGasUsed));
+      if (rpcResult.blobGasUsed !== undefined && rpcResult.blobGasUsed !== null) {
+        data.push(toBuffer(rpcResult.blobGasUsed));
       }
-      if (rpcResult.excessDataGas !== undefined && rpcResult.excessDataGas !== null) {
-        data.push(toBuffer(rpcResult.excessDataGas));
+      if (rpcResult.excessBlobGas !== undefined && rpcResult.excessBlobGas !== null) {
+        data.push(toBuffer(rpcResult.excessBlobGas));
+      }
+      if (rpcResult.parentBeaconBlockRoot !== undefined && rpcResult.parentBeaconBlockRoot !== null) {
+        data.push(toBuffer(rpcResult.parentBeaconBlockRoot));
       }
       return new this(data);
     } else {

--- a/src/header.js
+++ b/src/header.js
@@ -23,7 +23,9 @@ class Header extends EthObject {
       'mixHash',
       'nonce',
       'baseFeePerGas',
-      'withdrawalsRoot'
+      'withdrawalsRoot',
+      'dataGasUsed',
+      'excessDataGas'
     ]
   }
 
@@ -59,6 +61,12 @@ class Header extends EthObject {
       }
       if (rpcResult.withdrawalsRoot !== undefined && rpcResult.withdrawalsRoot !== null) {
         data.push(toBuffer(rpcResult.withdrawalsRoot));
+      }
+      if (rpcResult.dataGasUsed !== undefined && rpcResult.dataGasUsed !== null) {
+        data.push(toBuffer(rpcResult.dataGasUsed));
+      }
+      if (rpcResult.excessDataGas !== undefined && rpcResult.excessDataGas !== null) {
+        data.push(toBuffer(rpcResult.excessDataGas));
       }
       return new this(data);
     } else {


### PR DESCRIPTION
The current header encoding is extended with three fields:

`blobGasUsed` is the total amount of data gas consumed by the transactions within the block.
`excessBlobGas` is a running total of data gas consumed in excess of the target, prior to the block. Blocks with above-target data gas consumption increase this value, blocks with below-target data gas consumption decrease it (bounded at 0).
`parentBeaconBlockRoot`
